### PR TITLE
Use trim() on VERSION file

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -29,7 +29,7 @@ abstract class Event extends PhpObj {
      * @return [String => Mixed]
      */
     public function read(array $opts) {
-        $version = str_replace(PHP_EOL, '', file_get_contents(__DIR__.'/../../VERSION'));
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
         $version_key = 'https://github.com/LearningLocker/xAPI-Recipe-Emitter';
         $opts['context_info']->{$version_key} = $version;
         return [


### PR DESCRIPTION
Hi, this change just makes the removal of whitespace from the VERSION file more robust.

I was having problems with the unit tests failing on Windows, and it turned out to be because the VERSION file has an LF at the end that wasn't being removed (since my EOL sequence is CRLF). The unit tests pass after this change.