### PR TITLE
Add support for H5P xAPI events

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -23,7 +23,8 @@ class Controller extends PhpObj {
         'training_session_enrol' => 'EventEnrol',
         'training_session_unenrol' => 'EventUnenrol',
         'scorm_scoreraw_submitted' => 'ScormScoreRawSubmitted',
-        'scorm_status_submitted' => 'ScormStatusSubmitted'
+        'scorm_status_submitted' => 'ScormStatusSubmitted',
+        'hvp_xapi' => 'H5PxAPIEvent'
     ];
 
     /**

--- a/src/Events/H5PxAPIEvent.php
+++ b/src/Events/H5PxAPIEvent.php
@@ -1,0 +1,39 @@
+<?php namespace XREmitter\Events;
+
+class H5PxAPIEvent extends Event {
+
+    /**
+     * Reads data for an event.
+     * @param [String => Mixed] $opts
+     * @return [String => Mixed]
+     */
+    public function read(array $opts) {
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
+        $version_key = 'https://github.com/LearningLocker/xAPI-Recipe-Emitter';
+        $opts['context_info']->{$version_key} = $version;
+        $xapi_statement = unserialize($opts['context_ext']['other']);
+        return [
+            'actor' => $this->readUser($opts, 'user'),
+            'verb' => $xapi_statement['statement']['verb'],
+            'object' => $xapi_statement['statement']['object'],
+            'result' => $xapi_statement['statement']['result'],
+            'context' => [
+                'platform' => $opts['context_platform'],
+                'language' => $opts['context_lang'],
+                'extensions' => [
+                    $opts['context_ext_key'] => $opts['context_ext'],
+                    'http://lrs.learninglocker.net/define/extensions/info' => $opts['context_info'],
+                ],
+                'contextActivities' => [
+                    'grouping' => [
+                        $this->readApp($opts)
+                    ],
+                    'category' => [
+                        $this->readSource($opts)
+                    ]
+                ],
+            ],
+            'timestamp' => $opts['time'],
+        ];
+    }
+}


### PR DESCRIPTION
This PR is part of a set (Moodle-Log-Expander + Moodle-xAPI-Translator + xAPI-Recipe-Emitter ), which is complementing the changes made in h5p/h5p-moodle-plugin#114 as part of the Israeli Open University Academic English project (http://study.onl.co.il)

Please review and see if you can merge.