### PR TITLE
Removed Event's 'create' method which tried to call non-existent 'createEvent' method in 'Repository'.

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -45,7 +45,7 @@ class Controller extends PhpObj {
             $route = isset($opts['recipe']) ? $opts['recipe'] : '';
             if (isset(static::$routes[$route])) {
                 $event = '\XREmitter\Events\\'.static::$routes[$route];
-                $service = new $event($this->repo);
+                $service = new $event();
                 $opts['context_lang'] = $opts['context_lang'] ?: 'en';
                 array_push($statements, $service->read($opts));
             }

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -1,27 +1,8 @@
 <?php namespace XREmitter\Events;
-use \XREmitter\Repository as Repository;
 use \stdClass as PhpObj;
 
 abstract class Event extends PhpObj {
     protected static $verb_display;
-    protected $repo;
-
-    /**
-     * Constructs a new Event.
-     * @param repository $repo
-     */
-    public function __construct(Repository $repo) {
-        $this->repo = $repo;
-    }
-
-    /**
-     * Creates an event in the repository.
-     * @param [string => mixed] $event
-     * @return [string => mixed]
-     */
-    public function create(array $event) {
-        return $this->repo->createEvent($event);
-    }
 
     /**
      * Reads data for an event.

--- a/tests/AssignmentGradedTest.php
+++ b/tests/AssignmentGradedTest.php
@@ -9,7 +9,7 @@ class AssignmentGradedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/AssignmentSubmittedTest.php
+++ b/tests/AssignmentSubmittedTest.php
@@ -9,7 +9,7 @@ class AssignmentSubmittedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/AttemptCompletedTest.php
+++ b/tests/AttemptCompletedTest.php
@@ -9,7 +9,7 @@ class AttemptCompletedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/AttemptStartedTest.php
+++ b/tests/AttemptStartedTest.php
@@ -9,7 +9,7 @@ class AttemptStartedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/AttendedTest.php
+++ b/tests/AttendedTest.php
@@ -9,7 +9,7 @@ class AttendedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/CourseCompletedTest.php
+++ b/tests/CourseCompletedTest.php
@@ -24,7 +24,7 @@ class CourseCompletedTest extends EventTest
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     /**

--- a/tests/CourseViewedTest.php
+++ b/tests/CourseViewedTest.php
@@ -9,7 +9,7 @@ class CourseViewedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/DiscussionViewedTest.php
+++ b/tests/DiscussionViewedTest.php
@@ -9,7 +9,7 @@ class DiscussionViewedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/EnrolmentCreatedTest.php
+++ b/tests/EnrolmentCreatedTest.php
@@ -9,7 +9,7 @@ class EnrolmentCreatedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/EventEnrolTest.php
+++ b/tests/EventEnrolTest.php
@@ -9,7 +9,7 @@ class EventEnrolTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -6,11 +6,6 @@ use \Locker\XApi\Statement as Statement;
 abstract class EventTest extends PhpUnitTestCase {
     protected static $xapiType = 'http://lrs.learninglocker.net/define/type/moodle/';
     protected static $recipe_name;
-    protected $repo;
-
-    public function __construct() {
-        $this->repo = new TestRepository(new TestRemoteLrs('', '1.0.1', '', ''));
-    }
 
     /**
      * Sets up the tests.

--- a/tests/EventUnenrolTest.php
+++ b/tests/EventUnenrolTest.php
@@ -9,7 +9,7 @@ class EventUnenrolTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/ModuleViewedTest.php
+++ b/tests/ModuleViewedTest.php
@@ -9,7 +9,7 @@ class ModuleViewedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/QuestionAnsweredTest.php
+++ b/tests/QuestionAnsweredTest.php
@@ -9,7 +9,7 @@ class QuestionAnsweredTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/ScormEventTest.php
+++ b/tests/ScormEventTest.php
@@ -9,7 +9,7 @@ class ScormEventTest extends EventTest {
      * @override ModuleViewedTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/ScormLaunchedTest.php
+++ b/tests/ScormLaunchedTest.php
@@ -9,7 +9,7 @@ class ScormLaunchedTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/ScormScoreRawSubmittedTest.php
+++ b/tests/ScormScoreRawSubmittedTest.php
@@ -9,7 +9,7 @@ class ScormScoreRawSubmittedTest extends ScormEventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function assertOutput($input, $output) {

--- a/tests/ScormStatusSubmittedTest.php
+++ b/tests/ScormStatusSubmittedTest.php
@@ -9,7 +9,7 @@ class ScormStatusSubmittedTest extends ScormEventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function assertOutput($input, $output) {

--- a/tests/UserLoggedinTest.php
+++ b/tests/UserLoggedinTest.php
@@ -9,7 +9,7 @@ class UserLoggedinTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/UserLoggedoutTest.php
+++ b/tests/UserLoggedoutTest.php
@@ -9,7 +9,7 @@ class UserLoggedoutTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {

--- a/tests/UserRegisteredTest.php
+++ b/tests/UserRegisteredTest.php
@@ -9,7 +9,7 @@ class UserRegisteredTest extends EventTest {
      * @override EventTest
      */
     public function setup() {
-        $this->event = new Event($this->repo);
+        $this->event = new Event();
     }
 
     protected function constructInput() {


### PR DESCRIPTION
The `Event` class had a redundant dependency on the `Repository` class.

I've now removed that redundant dependency. 

The only reason `Event` needed to know about `Repository` was to try and call a **non-existent** method `createEvent` on it. Therefore, that code could never have been called (otherwise it would've thrown a PHP fatal error, because `Repository` doesn't have a `createEvent` method, only a `createEvents` (plural) one). 

All tests still pass.

(It's best to keep code as decoupled as possible.)